### PR TITLE
fix $classname if model is inside a subdirectory

### DIFF
--- a/src/FullSiteSearch.php
+++ b/src/FullSiteSearch.php
@@ -33,6 +33,9 @@ class FullSiteSearch
             return false;
         }
 
+        // if model is in subdirectory
+        $classname = str_replace('/', '\\', $classname);
+        
         // using reflection class to obtain class info dynamically
         $reflection = new \ReflectionClass(self::modelNamespacePrefix() . $classname);
 
@@ -117,6 +120,9 @@ class FullSiteSearch
             ->map([self::class, 'parseModelNameFromFile'])
             ->filter([self::class, 'filterSearchableModel'])
             ->map(function ($classname) use ($keyword) {
+                // if model is in subdirectory
+                $classname = str_replace('/', '\\', $classname);
+                
                 // for each class, call the search function
                 /** @var $model Model */
                 $model = app(self::modelNamespacePrefix() . $classname);


### PR DESCRIPTION
Models inside a subdirectory don't work

Ex:
```
Class: App\Models\Cart\Product

output: Cart/Product
```

fix: only need to replace every '/' for '\'